### PR TITLE
Update dependency restrictions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - hhvm
 
 before_script:
   - composer install --dev

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/process": "v2.4.2"
+        "symfony/process": "~2.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.0.*@dev"
+        "phpunit/phpunit": "~4.0"
     },
     "autoload": {
         "psr-0" : {


### PR DESCRIPTION
By allowing a newer Symfony/Process version tests will pass on hhvm.
