### PR TITLE
Implement TimeZone to run cronjobs in a specific timezone

### DIFF
--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -47,7 +47,10 @@ class Executor implements ExecutorInterface
      */
     protected function prepareSets(array $jobs)
     {
-        $now = new \DateTime();
+        $now = new \DateTime(
+            'now',
+            new \DateTimeZone(getenv('TZ') ?: date_default_timezone_get())
+        );
         $this->sets = [];
         foreach ($jobs as $job) {
             if ($job->valid($now)) {

--- a/src/Resolver/ArrayResolver.php
+++ b/src/Resolver/ArrayResolver.php
@@ -55,7 +55,10 @@ class ArrayResolver implements ResolverInterface
     public function resolve()
     {
         $jobs = [];
-        $now = new \DateTime();
+        $now = new \DateTime(
+            'now',
+            new \DateTimeZone(getenv('TZ') ?: date_default_timezone_get())
+        );
 
         foreach ($this->jobs as $job) {
             if ($job->valid($now)) {


### PR DESCRIPTION
For:
- https://github.com/Cron/Symfony-Bundle/issues/95 
- https://github.com/Cron/Cron/issues/70

Usage: 
`0 */3 * * * TZ="Europe/Amsterdam" /var/command > /dev/null 2>&1`