### PR TITLE
fix: deprecation implicitly marking parameter $env as nullable is deprecated, the explicit nullable type must be used instead for ShellJob

### DIFF
--- a/src/Job/ShellJob.php
+++ b/src/Job/ShellJob.php
@@ -25,7 +25,7 @@ class ShellJob extends AbstractProcessJob
      *
      * @param string $command
      */
-    public function setCommand($command, $cwd = null, array $env = null, $input = null, $timeout = 60, array $options = [])
+    public function setCommand($command, $cwd = null, ?array $env = null, $input = null, $timeout = 60, array $options = [])
     {
         if (method_exists(Process::class, 'fromShellCommandline')) {
             $this->process = Process::fromShellCommandline($command, $cwd, $env, $input, $timeout);


### PR DESCRIPTION
fix: deprecation implicitly marking parameter $env as nullable is deprecated, the explicit nullable type must be used instead for ShellJob)